### PR TITLE
README and subshell execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# idv
+
+## Quick Start
+
+- build-kernel.sh -	Script to build the kernel and install. Modifies kernel environment to accommodate gvt-g environment with newly build kernel
+- config.sh - Configure guest OS in /var/vm directory
+- install-guest-os.sh	- Help to install the guest OS
+- start-geust-os.sh	- Help to validate installed OS
+
+## Full documentation 
+
+The full documentation can be downloaded [here](./gvt-document-3.1.docx)

--- a/scripts/config-grub.sh
+++ b/scripts/config-grub.sh
@@ -23,8 +23,8 @@ function grub_setup() {
   if [[ $grub_modified -eq 1 ]]; then
     cmdline="GRUB_CMDLINE_LINUX=$cmdline\""
     sed -i "/.*GRUB_CMDLINE_LINUX=.*/c $cmdline" $tempfile
-    run_as_root "cp -f $tempfile $grubfile"
-    run_as_root "update-grub2"
+    cp -f $tempfile $grubfile
+    update-grub2
   fi
   rm -f $tempfile
 }

--- a/scripts/config-modules.sh
+++ b/scripts/config-modules.sh
@@ -9,9 +9,9 @@ modules=(kvmgt vfio-iommu-type1 vfio-mdev vfio-pci)
   echo "${green}Adding kernel modules.${NC}"
   for i in "${modules[@]}"; do
     echo $i
-    run_as_root "grep -qxF $i /etc/initramfs-tools/modules || echo $i >> /etc/initramfs-tools/modules"
+    grep -qxF $i /etc/initramfs-tools/modules || echo $i >> /etc/initramfs-tools/modules
   done
-#  run_as_root "update-initramfs -u -k all"
+  update-initramfs -u -k all
 }
 
 add_modules

--- a/scripts/util.sh
+++ b/scripts/util.sh
@@ -53,12 +53,12 @@ function update_idv_config() {
 
 function run_as_root() {
   cmd=$1
-echo "cmd: ($EUID) $cmd"
+  echo "cmd: ($EUID) $cmd"
   if [[ $EUID -eq 0 ]];then
-    ($cmd)
+    eval "$cmd"
   else
     sudo -s -E <<EOF
-    ($cmd)
+    eval "$cmd"
 EOF
    fi
 }


### PR DESCRIPTION
I wanted to commit an initial README. The full documentation currently a .docx file should be translated to something more modern. Many users don't use Microsoft word or Open Word.

Also there was an issue with executing run_as_root function and eval seems like the best practice since the bash subprocess is subject to literal escape characters. 

```bash
root@host:/opt/idv# ./build-kernel.sh
idv_config_file: /opt/idv/.idv-config
idv config file: /opt/idv/.idv-config
installing_packages dialog
cmd: (0) apt-get install -y dialog >/dev/null 2>&1
Reading package lists... Done
Building dependency tree
Reading state information... Done
E: Unable to locate package >/dev
E: Unable to locate package 2>&1
installing_packages bridge-utils
cmd: (0) apt-get install -y bridge-utils >/dev/null 2>&1
Reading package lists... Done
Building dependency tree
Reading state information... Done
E: Unable to locate package >/dev
E: Unable to locate package 2>&1
Adding kernel modules.
kvmgt
cmd: (0) grep -qxF kvmgt /etc/initramfs-tools/modules || echo kvmgt >> /etc/initramfs-tools/modules
grep: ||: No such file or directory
grep: echo: No such file or directory
grep: kvmgt: No such file or directory
grep: >>: No such file or directory
vfio-iommu-type1
cmd: (0) grep -qxF vfio-iommu-type1 /etc/initramfs-tools/modules || echo vfio-iommu-type1 >> /etc/initramfs-        tools/modules
grep: ||: No such file or directory
grep: echo: No such file or directory
grep: vfio-iommu-type1: No such file or directory
grep: >>: No such file or directory
vfio-mdev
cmd: (0) grep -qxF vfio-mdev /etc/initramfs-tools/modules || echo vfio-mdev >> /etc/initramfs-tools/modules
grep: ||: No such file or directory
grep: echo: No such file or directory
grep: vfio-mdev: No such file or directory
grep: >>: No such file or directory
vfio-pci
cmd: (0) grep -qxF vfio-pci /etc/initramfs-tools/modules || echo vfio-pci >> /etc/initramfs-tools/modules
/opt/idv/scripts/config-kernel.sh: line 3: ./idv-common: No such file or directory
```

